### PR TITLE
Corrected the parse where clause method in queryParser.js by changing regex

### DIFF
--- a/src/queryParser.js
+++ b/src/queryParser.js
@@ -179,7 +179,7 @@ function checkAggregateWithoutGroupBy(query, groupByFields) {
 }
 
 function parseWhereClause(whereString) {
-    const conditionRegex = /(.*?)(=|!=|>|<|>=|<=)(.*)/;
+    const conditionRegex = /(.*?)(=|!=|>=|<=|>|<)(.*)/;
     return whereString.split(/ AND | OR /i).map(conditionString => {
         const match = conditionString.match(conditionRegex);
         if (match) {


### PR DESCRIPTION
Previously the  regex was /(.*?)(=|!=|>|<|>=|<=)(.*)/  due to the ordering of < before <=, < is matched every time and = is left in value rather than in operator.
Example :- SELECT id FROM sample  WHERE age >= 20
here field : "age", operator : ">" , value : "= 20"

Changed the order of operators in regex to correct this issue 